### PR TITLE
Correção do rastreamento

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Desenvolvido a partir do manual de orientações técnicas, fornecido pela TNT B
  - Permite configurar faixas de CEPs, para restringir as cotações a regiões específicas.
  - Opção de cache das cotações.
  - Permite configurar um limite de tempo para as cotações.
+ - Permite rastrear a encomenda (requer cadastro da chave NFe nos comentários do pedido - 44 dígitos sem pontuação).
  - Extensão completamente gratuita, sem propagandas, ou versões pagas.
 
 ## Compatibilidade

--- a/app/code/community/Quack/TntBrasil/Helper/Data.php
+++ b/app/code/community/Quack/TntBrasil/Helper/Data.php
@@ -31,4 +31,20 @@ class Quack_TntBrasil_Helper_Data extends Mage_Core_Helper_Abstract
         $postcode = str_pad($postcode, $length, '0', STR_PAD_LEFT);
         return $postcode;
     }
+    
+    public function getNfeByOrder(Mage_Sales_Model_Order $order)
+    {
+        $nfeKey = '00000000000000000000000000000000000000000000';
+        foreach ($order->getAllStatusHistory() as $status) {
+            if (preg_match('/([\d]{44})/', $status->getData('comment'), $match)) {
+                $nfeKey = array_pop($match);
+                break;
+            }
+        }
+        $nfeSerie = (int)substr($nfeKey, 22, 3);
+        $nfeNumber = (int)substr($nfeKey, 25, 9);
+        
+        return array($nfeKey, $nfeSerie, $nfeNumber);
+    }
+    
 }

--- a/app/code/community/Quack/TntBrasil/Model/Abstract.php
+++ b/app/code/community/Quack/TntBrasil/Model/Abstract.php
@@ -253,7 +253,7 @@ abstract class Quack_TntBrasil_Model_Abstract extends Mage_Shipping_Model_Carrie
     {
         $progress = array();
         $finalStep = array();
-        $trackings = $response->out;
+        $trackings = array($response->out);
         
         foreach ($trackings as $track) {
             $progress[] = $this->_getTrackingProgressDetails($track);

--- a/app/code/community/Quack/TntBrasil/Model/Carrier.php
+++ b/app/code/community/Quack/TntBrasil/Model/Carrier.php
@@ -109,11 +109,11 @@ class Quack_TntBrasil_Model_Carrier extends Quack_TntBrasil_Model_Abstract
             $error->setTracking($code);
             $error->setCarrier($this->getCarrierCode());
             $error->setCarrierTitle($this->getConfigData('title'));
-    
+            
+            list($nf, $nfSerie) = explode('-', $code);
             $params = new TntMercurio_LocalizacaoIn();
-            $params->nf = (int)$code;
-            $params->pedido = 0;
-            $params->nfSerie = '001';
+            $params->nf = (int)$nf;
+            $params->nfSerie = (int)$nfSerie;
             $params->cnpj = (string)$this->getConfigData('api_vat');
             $params->usuario = $this->getConfigData('api_login');
             $request = new TntMercurio_Localizacao(array(), $this->getConfigData('url_tracking'));
@@ -121,9 +121,9 @@ class Quack_TntBrasil_Model_Carrier extends Quack_TntBrasil_Model_Abstract
             try {
                 $response = $request->localizaMercadoria(new TntMercurio_LocalizaMercadoria($params));
                 Mage::log(print_r($response, true));
-                $err = $response->out->erros;
+                $err = (array)$response->out->erros;
                 if (!empty($err)) {
-                    throw new Exception((string)$err);
+                    throw new Exception(print_r($err, true));
                 }
             } catch (Exception $e) {
                 $error->setErrorMessage($e->getMessage());

--- a/app/code/community/Quack/TntBrasil/etc/config.xml
+++ b/app/code/community/Quack/TntBrasil/etc/config.xml
@@ -27,7 +27,7 @@
 <config>
     <modules>
         <Quack_TntBrasil>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </Quack_TntBrasil>
     </modules>
     <global>


### PR DESCRIPTION
closes #3 
* Corrigido erro no rastreamento. Importante! O _webservice_ da TNT se limita a exibir somente a situação atual da encomenda.
* Adicionado requisito da chave da Nota Fiscal. A chave da NFe deve ser inserida nos comentários do pedido, para o pleno funcionamento do rastreamento. Cadastrar 44 dígitos numéricos, sem pontuação.